### PR TITLE
Fix parameter name of set_device('genn'): useGPU -> use_GPU

### DIFF
--- a/docs_sphinx/introduction/index.rst
+++ b/docs_sphinx/introduction/index.rst
@@ -67,7 +67,7 @@ generated, compiled and executed.
 The ``set_device`` function can also take additional arguments, e.g. to run
 GeNN in its "CPU-only" mode and to get additional debugging output, use::
 
-  set_device('genn', useGPU=False, debug=True)
+  set_device('genn', use_GPU=False, debug=True)
 
 Not all features of Brian work with Brian2GeNN. The current list of
 excluded features is detailed in :doc:`exclusions`.


### PR DESCRIPTION
Fixes a naming mistake in the documentation.

`set_device('genn', useGPU=False, debug=True)`
should be
`set_device('genn', use_GPU=False, debug=True)`

as that is the name in the run function of the GeNN device:
https://github.com/brian-team/brian2genn/blob/4da63141e9f4a6e4785349498e61e61e0ddae589/brian2genn/device.py#L1019

When using the wrong `useGPU` I get the following error message:
```
  File "...../python3.8/site-packages/brian2/devices/cpp_standalone/device.py", line 1514, in network_run
    self.build(direct_call=False, **self.build_options)
TypeError: build() got an unexpected keyword argument 'useGPU'
```
It works with `use_GPU`.